### PR TITLE
Adding support for YAML input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGELOG
 ==========
+## 0.3.1
+* Provide suport for task definition in YAML
+
 ## 0.3.0
 * Add GANTT Charts generation Thanks to [Google Charts Lib](https://developers.google.com/chart/interactive/docs/gallery/ganttchart)
 * Add support for NLP syntax parsing in clojurescript -

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ should not happen).
 :milestones-w-no-predecessors  | [1 2...  These milestones don't have predecessors.
 
 ### YAML task definition
-As an alternative to defining the tasks in EDN, Milestones provide a parser that can be used to describe them in YAML.
+As an alternative to defining the tasks in Clojure maps, Milestones provide a parser that can be used to describe them in YAML.
 For example, above sample case can be defined as:
 
 ```YAML

--- a/README.md
+++ b/README.md
@@ -276,6 +276,50 @@ should not happen).
 :tasks-cycles                  | [[1 2 3]... Set of tasks that are in a cycle. In this example, 2 depends on 1, 2 on 3 and 3 on 1.
 :milestones-w-no-predecessors  | [1 2...  These milestones don't have predecessors.
 
+### YAML task definition
+As an alternative to defining the tasks in EDN, Milestones provide a parser that can be used to describe them in YAML.
+For example, above sample case can be defined as:
+
+```YAML
+1:
+  task-name: Bring bread
+  resource-id: mehdi
+  duration: 5
+  priority: 1
+  predecessors: []
+2:
+  task-name: Bring butter
+  resource-id: rafik
+  duration: 5
+  priority: 1
+  predecessors: []
+3:
+  task-name: Put butter on bread
+  resource-id: salma
+  duration: 3
+  priority: 1
+  predecessors: [1, 2]
+4:
+  task-name: Eat toast
+  resource-id: rafik
+  duration: 4
+  priority: 1
+  predecessors: [3]
+5:
+  task-name: Eat toast
+  resource-id: salma
+  duration: 4
+  priority: 1
+  predecessors: [3]
+6:
+  task-name: Toasts ready
+  is-milestone: true
+  predecessors: [3]
+
+```
+
+You can use `parse-yaml-tasks` within `miltestones.yaml` namespace to convert the tasks before scheduling them.
+
 ## History
 
 The concept of auto-magic project scheduling is inspired from **the great**

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.turbopape/milestones "0.3.0"
+(defproject org.clojars.turbopape/milestones "0.3.1-SNAPSHOT"
   :description "Milestones : the Automagic Project Planner"
   :url "http://turbopape.github.io/milestones"
   :license {:name "MIT" 

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,8 @@
                  [prismatic/dommy "1.1.0"]
                  [org.clojure/core.async "0.2.391"
                   :exclusions [org.clojure/tools.reader]]
+                 [io.forward/yaml "1.0.5"]
+                 [cljsjs/js-yaml "3.3.1-0"]
                  [expectations "2.1.8"]]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]

--- a/src/milestones/yaml.cljc
+++ b/src/milestones/yaml.cljc
@@ -1,0 +1,21 @@
+(ns milestones.yaml
+  (:require #?(:clj  [yaml.core :refer [parse-string]]
+               :cljs [cljsjs.js-yaml])
+            [clojure.walk :refer [keywordize-keys]]
+            [milestones.dyna-scheduler :as d]))
+
+(defn parse
+  "Parses a YAML string to a clj(s) datastructure."
+  [yaml-str]
+  (let [parsed #?(:clj (parse-string yaml-str false)
+                  :cljs (->> yaml-str
+                             (.load js/jsyaml yaml-str)
+                             js->clj
+                             (map (fn [[id task]] [(js/parseInt id) task]))))]
+    (into {}
+          (map keywordize-keys parsed))))
+
+(defn schedule
+  "Shortcut to be able to call the scheduler with a YAML string instead of EDN definition"
+  [yaml-tasks reordering-properties]
+  (d/schedule (parse yaml-tasks) reordering-properties))

--- a/src/milestones/yaml.cljc
+++ b/src/milestones/yaml.cljc
@@ -4,7 +4,7 @@
             [clojure.walk :refer [keywordize-keys]]
             [milestones.dyna-scheduler :as d]))
 
-(defn parse
+(defn parse-yaml-tasks
   "Parses a YAML string to a clj(s) datastructure."
   [yaml-str]
   (let [parsed #?(:clj (parse-string yaml-str false)
@@ -14,8 +14,3 @@
                              (map (fn [[id task]] [(js/parseInt id) task]))))]
     (into {}
           (map keywordize-keys parsed))))
-
-(defn schedule
-  "Shortcut to be able to call the scheduler with a YAML string instead of EDN definition"
-  [yaml-tasks reordering-properties]
-  (d/schedule (parse yaml-tasks) reordering-properties))

--- a/test/milestones/yaml_test.clj
+++ b/test/milestones/yaml_test.clj
@@ -1,5 +1,6 @@
 (ns milestones.yaml-test
   (:require [milestones.yaml :as y]
+            [milestones.dyna-scheduler :refer [schedule]]
             [expectations :refer [expect]]))
 
 (def yaml-tasks
@@ -28,8 +29,8 @@
             :duration 3
             :priority 1
             :predecessors [1]}}
-        (y/parse yaml-tasks))
+        (y/parse-yaml-tasks yaml-tasks))
 
 ;; Check scheduling accepts the yaml parsed format
-(def scheduled (y/schedule yaml-tasks [:priority]))
+(def scheduled (schedule (y/parse-yaml-tasks yaml-tasks) [:priority]))
 (expect true (nil? (:error scheduled)))

--- a/test/milestones/yaml_test.clj
+++ b/test/milestones/yaml_test.clj
@@ -1,0 +1,35 @@
+(ns milestones.yaml-test
+  (:require [milestones.yaml :as y]
+            [expectations :refer [expect]]))
+
+(def yaml-tasks
+"1:
+   task-name : Bring bread
+   resource-id : mehdi
+   duration : 5
+   priority : 1
+   predecessors : []
+2:
+  task-name : Enjoy bread
+  resource-id : rafik
+  duration : 3
+  priority : 1
+  predecessors :
+     - 1")
+
+(expect {1 {:task-name "Bring bread"
+            :resource-id "mehdi"
+            :duration 5
+            :priority 1
+            :predecessors []}
+
+         2 {:task-name "Enjoy bread"
+            :resource-id "rafik"
+            :duration 3
+            :priority 1
+            :predecessors [1]}}
+        (y/parse yaml-tasks))
+
+;; Check scheduling accepts the yaml parsed format
+(def scheduled (y/schedule yaml-tasks [:priority]))
+(expect true (nil? (:error scheduled)))


### PR DESCRIPTION
I was playing with milestones so I took a stab at addressing issue #2.
The fact that EDN supports ints, keywords, string… as map keys and that YAML is not typed made it a bit less straight-forward than I initially thought.
The parse method expects Task IDs to be always integers.

Regards,
K.
